### PR TITLE
Add NavLink component to simplify links in headers/footers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1556,14 +1556,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@picocss/pico": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@picocss/pico/-/pico-2.0.6.tgz",
-      "integrity": "sha512-/d8qsykowelD6g8k8JYgmCagOIulCPHMEc2NC4u7OjmpQLmtSetLhEbt0j1n3fPNJVcrT84dRp0RfJBn3wJROA==",
-      "engines": {
-        "node": ">=18.19.0"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.4.tgz",
@@ -6628,9 +6620,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
-      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.3.tgz",
+      "integrity": "sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==",
       "dependencies": {
         "esbuild": "^0.19.3",
         "postcss": "^8.4.35",
@@ -7071,7 +7063,6 @@
       "dependencies": {
         "@astrojs/check": "^0.4.1",
         "@iconify-json/fa": "^1.1.8",
-        "@picocss/pico": "^2.0.6",
         "astro": "^4.0.6",
         "astro-icon": "^1.0.4",
         "typescript": "^5.3.3"

--- a/packages/astro/src/components/FooterNav.astro
+++ b/packages/astro/src/components/FooterNav.astro
@@ -1,7 +1,8 @@
 ---
 import { Icon } from "astro-icon/components";
+import NavLink from "./NavLink.astro";
 
-const routes = [
+const columns = [
   [
     "Resources",
     [
@@ -31,86 +32,65 @@ const routes = [
       ["https://www.facebook.com/codeforsanfrancisco", "facebook", true],
       ["https://www.linkedin.com/company/18115347/", "linkedin", true],
       ["https://github.com/sfbrigade/", "github", true],
-      ["http://c4sf.me/slack", "slack", true],
+      ["https://c4sf.me/slack", "slack", true],
       ["https://www.meetup.com/sfcivictech/", "meetup", true],
     ],
   ],
 ] as const;
-// because of annoying differences between dev and build modes, due to this
-// behavior (https://github.com/withastro/astro/issues/5630), always remove
-// any trailing slash so currentPage can match the pages above
-const fullPath = Astro.url.pathname.replace(/\/$/, "");
-const currentPage = fullPath.slice(fullPath.lastIndexOf("/") + 1);
 ---
 
-<nav class="container">
-  <ul class="grid footer-list container">
-    {
-      routes.map(([cat, links]) => (
-        <li class="footer-list-item">
-          <h3 class="footer-list-cat-name contrast">{cat}</h3>
-          <ul class="footer-list-cat-list">
-            {links.map(([page, label, needsIcon]) => (
-              <li class="footer-list-cat-list-item container">
-                {needsIcon ? (
-                  <span class="icon-container">
-                    <Icon name={"fa:" + label} />{" "}
-                  </span>
-                ) : (
-                  ""
-                )}{" "}
-                <a
-                  href={page}
-                  aria-current={currentPage === page ? "page" : false}
-                >
-                  {label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </li>
-      ))
-    }
-  </ul>
-</nav>
+<footer class="container">
+	<nav>
+		{columns.map(([cat, links]) => (
+			<div>
+				<h3>{cat}</h3>
+				<ul>
+					{links.map(([page, label, needsIcon]) => (
+						<li class="footer-list-cat-list-item ">
+							{needsIcon &&
+								// adding a class attribute to the <Icon> component works just fine
+								// but TS complains, so tell it to keep quiet
+								// @ts-ignore
+								<Icon name={"fa:" + label} class={"icon"} />
+							}
+							<NavLink href={page}>
+								{label}
+							</NavLink>
+						</li>
+					))}
+				</ul>
+			</div>
+		))}
+	</nav>
+</footer>
 
 <style>
-  a[aria-current] {
-    --color: var(--contrast);
-    cursor: default;
-    pointer-events: none;
-  }
-  .nav-header {
-    display: flex;
-  }
-  .footer-list {
-    /*display: flex;*/
-    align-items: start;
-  }
-  .footer-list-item {
-    flex: 1;
-    list-style-type: none;
-    vertical-align: top;
-  }
-  .footer-list-cat-name {
+	h3 {
+		font-size: 1.25rem;
     margin: 0;
     text-transform: uppercase;
   }
-  .footer-list-cat-list {
+
+  ul {
+		--nav-element-spacing-horizontal: 0;
     align-items: start;
     display: flex;
     flex-direction: column;
-    margin-left: 0;
   }
-  .footer-list-cat-list-item {
-    list-style-type: none;
+
+	ul:first-of-type, ul:last-of-type {
+		margin-left: initial;
+		margin-right: initial;
+	}
+
+  li {
     margin: 0;
     padding: 0;
   }
 
-  .icon-container {
+  .icon {
     display: inline-block;
-    min-width: 36px;
+    min-width: 1.5rem;
     text-align: center;
   }
 </style>

--- a/packages/astro/src/components/HeaderNav.astro
+++ b/packages/astro/src/components/HeaderNav.astro
@@ -1,78 +1,50 @@
 ---
+import NavLink from "./NavLink.astro";
+import NavDropdown from "./NavDropdown.astro";
+
 const routes = [
 	{ label: "Wiki", page: "wiki" },
-    { label: "Get Started", page: "getting-started" },
-    { label: "Events", page: "events" },
-    { label: "Projects", page: "projects" },
-    { label: "Blog", page: "blog" },
-    { label: "Donate", page: "donate" },
+	{ label: "Get Started", page: "getting-started" },
+	{ label: "Events", page: "events" },
+	{ label: "Projects", page: "projects" },
+	{ label: "Blog", page: "blog" },
+	{ label: "Donate", page: "donate" },
 	{ label: "About", page: "about",
-        pages: [
-            { label: "Code of Conduct", page: "about/code-of-conduct" }
-        ]
-    }
+		pages: [
+			{ label: "Code of Conduct", page: "about/code-of-conduct" }
+		]
+	}
 ];
-// because of annoying differences between dev and build modes, due to this
-// behavior (https://github.com/withastro/astro/issues/5630), always remove
-// any trailing slash so currentPage can match the pages above
-const fullPath = Astro.url.pathname.replace(/\/$/, "");
-const currentPage = fullPath.slice(fullPath.lastIndexOf("/") + 1);
 ---
 
-<nav class="container">
-	<ul>
-		<li>
-			<a href="./" class="contrast">
-				<strong>SF Civic Tech</strong>
-			</a>
-		</li>
-	</ul>
-	<ul>
-		{routes.map(route => (
-            <li class={`nav-item ${!!route.pages?.length ? "dropdown" : ""}`}>
-                <a href={route.page} aria-current={currentPage === route.page ? "page" : false}>{route.label}</a>
-                {!!route.pages?.length &&
-                    <div class="dropdown-content">
-                        {route.pages.map(page => (
-                            <a href={page.page} aria-current={currentPage === page.page ? "page" : false}>{page.label}</a>
-                        ))}
-                    </div>
-                }
-            </li>
-        ))}
-	</ul>
-</nav>
+<header class="container">
+	<nav>
+		<ul>
+			<li>
+				{/* the href of "" on the homepage link here looks a little weird, but the base
+					path is prefixed to these links, so basePath + "" == the root page */}
+				<NavLink href="" class="contrast">
+					<strong>SF Civic Tech</strong>
+				</NavLink>
+			</li>
+		</ul>
+		<ul>
+			{routes.map(({ label, page, pages }) => (
+				<li>
+					<NavLink href={page}>
+						{label}
+					</NavLink>
+					{!!pages?.length &&
+						<NavDropdown items={pages} />
+					}
+				</li>
+			))}
+		</ul>
+	</nav>
+</header>
 
 <style>
-	a[aria-current] {
-		--color: var(--contrast);
-		cursor: default;
-		pointer-events: none;
+	header {
+		padding: 0;
 	}
-
-	.dropdown {
-        position: relative;
-        display: inline-block;
-    }
-
-    .dropdown-content {
-        display: none;
-        position: absolute;
-        background-color: #f9f9f9;
-        min-width: 160px;
-        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-        z-index: 1;
-    }
-
-    .dropdown-content a {
-        color: black;
-        padding: 12px 16px;
-        text-decoration: none;
-        display: block;
-    }
-
-    .dropdown:hover .dropdown-content {
-        display: block;
-    }
-
 </style>

--- a/packages/astro/src/components/NavDropdown.astro
+++ b/packages/astro/src/components/NavDropdown.astro
@@ -1,0 +1,41 @@
+---
+import NavLink from "./NavLink.astro";
+
+interface Props {
+	items: { label: string; page: string }[];
+}
+
+const { items } = Astro.props;
+---
+
+<div class="dropdown-content">
+	{items.map(({ label, page }) => (
+		<NavLink href={page}>
+			{label}
+		</NavLink>
+	))}
+</div>
+
+<style>
+	.dropdown-content {
+		display: none;
+		position: absolute;
+		background-color: #f9f9f9;
+		white-space: nowrap;
+		padding: .5rem 1rem;
+		right: 0;
+		top: 80%;
+		box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
+		z-index: 1;
+	}
+
+	/* set global styles on li's inside a nav, since we can't target their scoped
+			styles from here */
+	:global(nav li) {
+		position: relative;
+	}
+
+	:global(nav li):hover > .dropdown-content {
+		display: block;
+	}
+</style>

--- a/packages/astro/src/components/NavLink.astro
+++ b/packages/astro/src/components/NavLink.astro
@@ -1,0 +1,32 @@
+---
+interface Props {
+	href: string;
+	class?: string;
+}
+
+	// we can destructure `class` from props, but we have to rename it so it won't
+	// trigger syntax errors in the JS
+const { href, class: className } = Astro.props;
+
+	// remove the base URL from the beginning of the current page so we can match
+	// it against the href prop, which shouldn't include any base URL.  because of
+	// annoying differences between dev and build modes, due to this behavior
+	// (https://github.com/withastro/astro/issues/5630), we also have to remove
+	// any trailing slash so currentPage can match the href.
+const currentPage = Astro.url.pathname
+	.replace(import.meta.env.BASE_URL, "")
+	.replace(/\/$/, "");
+const ariaCurrent = currentPage === href ? "page" : false;
+---
+
+<a href={href} class={className} aria-current={ariaCurrent}>
+	<slot />
+</a>
+
+<style>
+	a[aria-current] {
+		--pico-color: var(--pico-contrast);
+		cursor: default;
+		pointer-events: none;
+	}
+</style>

--- a/packages/astro/src/components/NewsSummaryItem.astro
+++ b/packages/astro/src/components/NewsSummaryItem.astro
@@ -24,7 +24,7 @@ const postURL = "blog/" + slug;
 		aspect-ratio: 1;
 		background-size: cover;
 		background-position: center;
-		padding: var(--block-spacing-horizontal);
+		padding: var(--pico-block-spacing-horizontal);
 		overflow: hidden;
 		position: relative;
 		flex-direction: column;
@@ -37,7 +37,7 @@ const postURL = "blog/" + slug;
 	}
 
 	article h3 {
-		--color: white;
+		--pico-color: white;
 		font-size: 1rem;
 		margin-bottom: 0;
 		position: relative;

--- a/packages/astro/src/layouts/BaseLayout.astro
+++ b/packages/astro/src/layouts/BaseLayout.astro
@@ -15,7 +15,5 @@ const { title } = Astro.props;
   <main class="container">
     <slot />
   </main>
-  <footer>
-    <FooterNav />
-  </footer>
+	<FooterNav />
 </Page>

--- a/packages/astro/src/layouts/Page.astro
+++ b/packages/astro/src/layouts/Page.astro
@@ -1,5 +1,6 @@
 ---
 import "@picocss/pico";
+import "./global.css";
 
 interface Props {
 	title: string;
@@ -23,4 +24,3 @@ const { title } = Astro.props;
 		<slot />
 	</body>
 </html>
-

--- a/packages/astro/src/layouts/global.css
+++ b/packages/astro/src/layouts/global.css
@@ -1,0 +1,12 @@
+:root {
+	--pico-block-spacing-horizontal: 2rem;
+	--pico-block-spacing-vertical: 3rem;
+}
+
+.container {
+	max-width: 1100px;
+}
+
+article {
+	margin: var(--pico-block-spacing-vertical) 0;
+}


### PR DESCRIPTION
- Taking the base URL into account when checking whether the current page is the same as one of the nav links is handled inside NavLink.astro.
- You can pass in a class prop to apply to the NavLink anchor.
- Add NavDropdown component to simplify the creation and styling of the header dropdown menus.
- Add header and footer tags inside the components.
- Fix the TypeScript errors.
- Adjust some of the styles to work with Pico v2.